### PR TITLE
Docker コンテナ内で操作したコマンドのヒストリーが作られない件について Dockerfile を修正

### DIFF
--- a/.docker/app/Dockerfile
+++ b/.docker/app/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir ${COMPOSER_HOME} && \
-    chown -R www-data: ${COMPOSER_HOME}
+    chown -R www-data: ${COMPOSER_HOME} && \
+    chown -R www-data: /var/www
 
 USER www-data


### PR DESCRIPTION
- $HISTFILE について /var/www/.bash_history を指すため /var/www ディレクトリについて www-data 所有に更新することで解決